### PR TITLE
그룹 추천/배지/참여 관리 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "author": "",
   "type": "module",
   "main": "index.js",
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,3 +13,82 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+
+model Group {
+  id                Int             @id @default(autoincrement())
+  ownerParticipantId Int?
+  name              String
+  description       String
+  photoUrl          String?
+  goalRep           Int
+  discordWebhookUrl String?
+  discordInviteUrl  String?
+  likeCount         Int             @default(0)
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
+
+  participants      Participant[]
+  records           Record[]
+  badges            BadgeToGroup[]
+
+  @@index([name])
+}
+
+model Participant {
+  id         Int       @id @default(autoincrement())
+  groupId    Int
+  nickname   String
+  password   String     // bcrypt 해시 저장
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+
+  group      Group     @relation(fields: [groupId], references: [id])
+  records    Record[]
+
+  // 같은 그룹 내 닉네임 중복 방지
+  @@unique([groupId, nickname], name: "groupId_nickname")
+}
+
+model Record {
+  id            Int        @id @default(autoincrement())
+  groupId       Int
+  participantId Int
+  type          RecordType
+  description   String?
+  timeSec       Int
+  distanceM     Int?
+  photos        String[]   // 최대 3장은 서비스단에서 체크
+  createdAt     DateTime   @default(now())
+
+  group         Group      @relation(fields: [groupId], references: [id])
+  participant   Participant @relation(fields: [participantId], references: [id])
+
+  @@index([groupId])
+  @@index([participantId])
+}
+
+enum RecordType {
+  RUN
+  BIKE
+  SWIM
+}
+
+model Badge {
+  id    Int     @id @default(autoincrement())
+  name  String  @unique     // 'TEN_PARTICIPANTS' | 'HUNDRED_RECORDS' | 'HUNDRED_LIKES'
+  label String
+
+  groups BadgeToGroup[]
+}
+
+model BadgeToGroup {
+  groupId   Int
+  badgeId   Int
+  awardedAt DateTime @default(now())
+
+  group Group @relation(fields: [groupId], references: [id])
+  badge Badge @relation(fields: [badgeId], references: [id])
+
+  @@id([groupId, badgeId]) // 한 그룹에 같은 배지는 1번만
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // 기본 배지 3종 업서트
+  await prisma.badge.upsert({
+    where: { name: 'TEN_PARTICIPANTS' },
+    update: {},
+    create: { name: 'TEN_PARTICIPANTS', label: '참여자 10명 달성' },
+  });
+  await prisma.badge.upsert({
+    where: { name: 'HUNDRED_RECORDS' },
+    update: {},
+    create: { name: 'HUNDRED_RECORDS', label: '운동 기록 100개 달성' },
+  });
+  await prisma.badge.upsert({
+    where: { name: 'HUNDRED_LIKES' },
+    update: {},
+    create: { name: 'HUNDRED_LIKES', label: '추천수 100회 달성' },
+  });
+}
+
+main()
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import groupRoutes from './routes/group.routes.js';
+// ...기존 import들
+
+const app = express();
+
+app.use(express.json());
+// ...기존 미들웨어
+
+app.use('/groups', groupRoutes); // << 추가
+
+// ...기존 에러 핸들러
+export default app;

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -1,1 +1,4 @@
-// db.ts
+// Prisma 클라이언트 인스턴스
+import { PrismaClient } from '../generated/prisma/index.js';
+
+export const prisma = new PrismaClient();

--- a/src/controllers/group.controllers.ts
+++ b/src/controllers/group.controllers.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction } from 'express';
+import * as groupService from '../services/group.service.js';
+
+// 추천(좋아요) 1 증가
+export async function recommendGroup(req: Request, res: Response, next: NextFunction) {
+  try {
+    const groupId = Number(req.params.groupId);
+    const result = await groupService.recommendGroup(groupId);
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+// 그룹 참여
+export async function joinGroup(req: Request, res: Response, next: NextFunction) {
+  try {
+    const groupId = Number(req.params.groupId);
+    const { nickname, password } = req.body;
+    const created = await groupService.joinGroup(groupId, { nickname, password });
+    res.status(201).json(created);
+  } catch (err) {
+    next(err);
+  }
+}
+
+// 그룹 탈퇴
+export async function leaveGroup(req: Request, res: Response, next: NextFunction) {
+  try {
+    const groupId = Number(req.params.groupId);
+    const { nickname, password } = req.body;
+    const ok = await groupService.leaveGroup(groupId, { nickname, password });
+    res.json({ left: ok });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/routes/group.routes.ts
+++ b/src/routes/group.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { recommendGroup, joinGroup, leaveGroup } from '../controllers/group.controllers.js';
+
+// 필요시 여기서 전용 미들웨어(레이트리밋 등)도 붙일 수 있음
+const router = Router();
+
+router.post('/:groupId/recommend', recommendGroup); // 추천 1 증가
+router.post('/:groupId/join',       joinGroup);      // 참여
+router.post('/:groupId/leave',      leaveGroup);     // 탈퇴
+
+export default router;

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -1,0 +1,146 @@
+import bcrypt from 'bcryptjs';
+import { prisma } from '../config/db.js'; // 네 프로젝트의 Prisma 클라이언트 export (db.ts)
+
+// 서비스 내부 상수: 배지 키
+const BADGES = {
+  TEN_PARTICIPANTS: 'TEN_PARTICIPANTS',
+  HUNDRED_RECORDS: 'HUNDRED_RECORDS',
+  HUNDRED_LIKES: 'HUNDRED_LIKES',
+} as const;
+
+// 추천(좋아요) 1 증가 → 배지 재평가
+export async function recommendGroup(groupId: number) {
+  // 원자적 증가(increment)는 동시성 안전
+  const updated = await prisma.group.update({
+    where: { id: groupId },
+    data: { likeCount: { increment: 1 } },
+    select: { id: true, likeCount: true },
+  });
+
+  await evaluateAndAwardBadges(groupId);
+  return updated;
+}
+
+// 그룹 참여(닉네임 중복 방지, 비밀번호 해시)
+export async function joinGroup(
+  groupId: number,
+  payload: { nickname: string; password: string }
+) {
+  const { nickname, password } = payload;
+  if (!nickname || !password) {
+    const err = new Error('nickname/password 필수');
+    (err as any).status = 400;
+    throw err;
+  }
+
+  const hash = await bcrypt.hash(password, 10);
+
+  // 트랜잭션: 참가자 생성 → 배지 검사(참여자수 10명 조건)
+  const created = await prisma.$transaction(async (tx) => {
+    try {
+      const participant = await tx.participant.create({
+        data: { groupId, nickname, password: hash },
+        select: { id: true, groupId: true, nickname: true, createdAt: true },
+      });
+
+      await evaluateAndAwardBadges(groupId, tx);
+      return participant;
+    } catch (e: any) {
+      // (groupId, nickname) 유니크 충돌
+      if (e.code === 'P2002') {
+        const err = new Error('이미 사용 중인 닉네임입니다.');
+        (err as any).status = 409;
+        throw err;
+      }
+      throw e;
+    }
+  });
+
+  return created;
+}
+
+// 그룹 탈퇴(비번 검증, 기록 동반 삭제)
+export async function leaveGroup(
+  groupId: number,
+  payload: { nickname: string; password: string }
+) {
+  const { nickname, password } = payload;
+  if (!nickname || !password) {
+    const err = new Error('nickname/password 필수');
+    (err as any).status = 400;
+    throw err;
+  }
+
+  const user = await prisma.participant.findUnique({
+    where: { groupId_nickname: { groupId, nickname } },
+    select: { id: true, password: true },
+  });
+  if (!user) {
+    const err = new Error('참여자 없음');
+    (err as any).status = 404;
+    throw err;
+  }
+
+  const ok = await bcrypt.compare(password, user.password);
+  if (!ok) {
+    const err = new Error('비밀번호 불일치');
+    (err as any).status = 401;
+    throw err;
+  }
+
+  // 기록 → 참가자 순으로 삭제(참조 무결성)
+  await prisma.$transaction(async (tx) => {
+    await tx.record.deleteMany({ where: { participantId: user.id } });
+    await tx.participant.delete({ where: { id: user.id } });
+    // 보통 획득 배지는 회수하지 않음(정책에 따라 다름)
+  });
+
+  return true;
+}
+
+/* ---------------------- */
+/* 배지 평가/부여 공용함수 */
+/* ---------------------- */
+
+// tx가 주어지면 그 트랜잭션으로 실행(없으면 전역 prisma)
+async function evaluateAndAwardBadges(groupId: number, tx = prisma) {
+  // 한 번의 질의로 카운트/보유배지 스냅샷 확보 → ORM 최적화 포인트
+  const snapshot = await tx.group.findUnique({
+    where: { id: groupId },
+    select: {
+      id: true,
+      likeCount: true,
+      _count: { select: { participants: true, records: true } },
+      badges: { select: { badge: { select: { name: true } } } },
+    },
+  });
+  if (!snapshot) return;
+
+  const owned = new Set(snapshot.badges.map((b) => b.badge.name));
+  const toGive: string[] = [];
+
+  if (snapshot._count.participants >= 10 && !owned.has(BADGES.TEN_PARTICIPANTS)) {
+    toGive.push(BADGES.TEN_PARTICIPANTS);
+  }
+  if (snapshot._count.records >= 100 && !owned.has(BADGES.HUNDRED_RECORDS)) {
+    toGive.push(BADGES.HUNDRED_RECORDS);
+  }
+  if (snapshot.likeCount >= 100 && !owned.has(BADGES.HUNDRED_LIKES)) {
+    toGive.push(BADGES.HUNDRED_LIKES);
+  }
+  if (toGive.length === 0) return;
+
+  // 배지 id 매핑 조회 후 조합키([groupId,badgeId])로 중복 부여 방지
+  const badges = await tx.badge.findMany({
+    where: { name: { in: toGive } },
+    select: { id: true, name: true },
+  });
+
+  await Promise.all(
+    badges.map((b) =>
+      tx.badgeToGroup.create({
+        data: { groupId, badgeId: b.id },
+      })
+    )
+  );
+}


### PR DESCRIPTION
- 그룹 추천 API (POST /groups/:id/recommend)
- 그룹 참여/탈퇴 API (POST /groups/:id/join, /groups/:id/leave)
- 배지 시스템 (참여자 10명, 기록 100개, 추천 100회 달성)
- bcrypt 비밀번호 해싱 및 닉네임 중복 방지
- Prisma 트랜잭션 기반 데이터 무결성 보장
